### PR TITLE
A way to set whether to use indentLine at startup

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -58,6 +58,9 @@ endfunction
 function! <SID>SetIndentLine()
     if !exists("b:indentLine_enabled")
         let b:indentLine_enabled = g:indentLine_enabled
+        if !b:indentLine_enabled
+            return
+        endif
     endif
 
     let space = &l:shiftwidth


### PR DESCRIPTION
I need this function..

I also use a following map to make things work together better..
nnoremap <leader>ig :IndentLinesToggle<CR>:set list! lcs=tab:\|<Space><CR>
