### PR TITLE
Change the type of the variables for "FileType Supported" to list

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -29,11 +29,11 @@ if !exists("g:indentLine_enabled")
 endif
 
 if !exists("g:indentLine_fileType")
-    let g:indentLine_fileType = "*"
+    let g:indentLine_fileType = []
 endif
 
 if !exists("g:indentLine_fileTypeExclude")
-    let g:indentLine_fileTypeExclude = ""
+    let g:indentLine_fileTypeExclude = [] 
 endif
 
 set conceallevel=1
@@ -105,9 +105,13 @@ function! <SID>Setup()
     if !exists("b:indentLine_set")
         let b:indentLine_set = 1
 
-        if !empty(filter(split(g:indentLine_fileTypeExclude, ','), 'v:val ==? "*.".expand("%:e:e") || v:val == "*"'))
+        if index(g:indentLine_fileTypeExclude, &ft) != -1
             return
         endif
+
+        if len(g:indentLine_fileType) != 0 && index(g:indentLine_fileType, &ft) == -1
+            return
+        end
 
         if !exists("b:indentLine_enabled")
             let b:indentLine_enabled = g:indentLine_enabled
@@ -124,8 +128,8 @@ function! <SID>Setup()
 endfunction
 
 "{{{1 commands
-exec 'autocmd BufWinEnter '.g:indentLine_fileType.' call <SID>Setup()'
-exec 'autocmd BufRead,ColorScheme '.g:indentLine_fileType.' call <SID>InitColor()'
+exec 'autocmd BufWinEnter * call <SID>Setup()'
+exec 'autocmd BufRead,ColorScheme * call <SID>InitColor()'
 
 command! -nargs=? IndentLinesReset call <SID>ResetWidth(<f-args>)
 command! IndentLinesToggle call <SID>IndentLinesToggle()

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -51,18 +51,18 @@ g:indentLine_enabled                            *g:indentLine_enabled*
                 Default value is 1.
 
 g:indentLine_fileType                           *g:indentLine_fileType*
-                This variable specify a list of comma separated file types.
+                This variable specify a list of file types.
                 When opening these types of files, the plugin is enabled by
                 default.
-                e.g. let g:indentLine_fileType = '*.c,*.h'
-                Default value is "*" which means all file types is supported.
+                e.g. let g:indentLine_fileType = ['c', 'cpp']
+                Default value is [] which means all file types is supported.
 
 g:indentLine_fileTypeExclude                    *g:indentLine_fileTypeExclude*
-                This variable specify a list of comma separated file types.
+                This variable specify a list of file types.
                 When opening these types of files, the plugin is disabled by
                 default.
-                e.g. let g:indentLine_fileType = '*.txt,*.sh'
-                Default value is "" which means no file types is excluded.
+                e.g. let g:indentLine_fileType = ['text', 'sh']
+                Default value is [] which means no file types is excluded.
 
 ==============================================================================
 COMMANDS                                         *indentLine-commands*


### PR DESCRIPTION
Due to the bad performance of opening the big files, it is very necessary to add "FileType Supported". However, I found a bug that I couldn't make the plugin disable for a file without a extension. Besides, I often handle dataset files which are often big and have a variety of extensions and I don't think that it is convenient for me to add the file type to the config file when I meet a new file type. Luckily, vim recognize the type of these files as "".

Therefore, I suggest that you should change the type of the variables for "FileType Supported" to list and control the behaviors of the plugin depending on the value of the built-in variable "&ft".

Thanks for reading.
