### PR TITLE
Performance improvement

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -70,7 +70,7 @@ function! <SID>SetIndentLine()
     let b:indentLine_enabled = 1
     let space = &l:shiftwidth
     for i in range(space+1, space * g:indentLine_indentLevel + 1, space)
-        exec 'syn match IndentLine /\(^\s\+\)\@<=\%'.i.'v / containedin=ALL conceal cchar=' . g:indentLine_char
+        exec 'syn match IndentLine /\(^\s\+\)\@<=\%'.i.'c / conceal cchar=' . g:indentLine_char
     endfor
 endfunction
 


### PR DESCRIPTION
To use the pattern /(^\s\+)\@<=\%'.i.'c / instead of /(^\s\+)\@<=\%'.i.'v / can improve the performance of the plugin.

I tried to open [jquery.js](http://code.jquery.com/jquery-1.9.1.js) and vim lagged for less than 1 second which reduces from about 2 seconds. 
