### PR TITLE
Fix issue #21

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -36,6 +36,10 @@ if !exists("g:indentLine_fileTypeExclude")
     let g:indentLine_fileTypeExclude = []
 endif
 
+if !exists("g:indentLine_showFirstIndentLevel")
+    let g:indentLine_showFirstIndentLevel = 0
+endif
+
 set conceallevel=1
 set concealcursor=inc
 
@@ -69,6 +73,11 @@ endfunction
 function! <SID>SetIndentLine()
     let b:indentLine_enabled = 1
     let space = &l:shiftwidth
+
+    if g:indentLine_showFirstIndentLevel
+        exec 'syn match IndentLine /^ / containedin=ALL conceal cchar=' . g:indentLine_char
+    endif
+
     for i in range(space+1, space * g:indentLine_indentLevel + 1, space)
         exec 'syn match IndentLine /\(^\s\+\)\@<=\%'.i.'v / containedin=ALL conceal cchar=' . g:indentLine_char
     endfor

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -45,6 +45,12 @@ g:indentLine_indentLevel                        *g:indentLine_indentLevel*
                 10.
                 Default value is 10.
 
+g:indentLine_showFirstIndentLevel               *g:indentLine_showFirstIndentLevel*
+                Specify whether the first indent level should be shown.
+                This is useful if you use indentLine in comination with
+                |listchars| in order to show tabs.
+                Default value is 0.
+
 g:indentLine_enabled                            *g:indentLine_enabled*
                 Specify whether to enable indentLine plugin by default.
                 If value is not 0, the plugin is on by default, otherwise off.


### PR DESCRIPTION
I added the feature to optionally show the first indentation level. Can be switched on with:

``` vim
let g:indentLine_showFirstIndentLevel=1
```

Default is `0`, meaning disabled. Here's an example:

![screenshot](https://f.cloud.github.com/assets/115889/258778/6ea59484-8ca8-11e2-9fd6-51d54c8ccc5a.png)

Please merge, if you like it!

Cheers, Patrick
