### PR TITLE
Suggestion: provide a variable to configure whether or not load the feature when initializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ for GVim, set `g:indentLine_color_gui` in your `.vimrc`, e.g. `let g:indentLine_
 You can also change the indentLine char:  
 for both Vim and GVim, set `let g:indentLine_char = 'c'` where `'c'` can be any ASCII character. You can also use one of `¦`, `┆` or `│` to display more beautiful lines. However, these characters will only work with files whose encoding is UTF-8.
 
+You can deside whether or not load this plugin when vim initialize:
+`let g:indentLine_init_enabled = 0` not load when initialization or,
+`let g:indentLine_init_enabled = 1` load when initialization.
+
 ## Self promotion
 If you think this script is helpful, follow the [GitHub repository][repository], and don't forget to vote for it on Vim.org! ([vimscript #4354][script]).
 

--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -1,61 +1,39 @@
 " Script Name: indentLine.vim
-" Version:     1.0.5
-" Last Change: April 1, 2013
+" Version:     1.0.4
+" Last Change: Jan 23, 2013
 " Author:      Yggdroot <archofortune@gmail.com>
 "
-" Description: To show the indention levels with thin vertical lines
+" Description: To show the indent lines
 
-"{{{1 global variables
 if !has("conceal") || exists("g:indentLine_loaded")
     finish
 endif
 let g:indentLine_loaded = 1
 
-" | ¦ ┆ ┊ │
 if !exists("g:indentLine_char")
+    " | ¦ ┆  │
     if &encoding ==? "utf-8"
         let g:indentLine_char = "¦"
     else
-        let g:indentLine_char = "|"
-    endif
-endif
-
-if !exists("g:indentLine_first_char")
-    if &encoding ==? "utf-8"
-        let g:indentLine_first_char = "¦"
-    else
-        let g:indentLine_first_char = "|"
+        let  g:indentLine_char = "|"
     endif
 endif
 
 if !exists("g:indentLine_indentLevel")
-    let g:indentLine_indentLevel = 10
+    let g:indentLine_indentLevel = 20
 endif
 
 if !exists("g:indentLine_enabled")
     let g:indentLine_enabled = 1
 endif
 
-if !exists("g:indentLine_fileType")
-    let g:indentLine_fileType = []
-endif
-
-if !exists("g:indentLine_fileTypeExclude")
-    let g:indentLine_fileTypeExclude = []
-endif
-
-if !exists("g:indentLine_bufNameExclude")
-    let g:indentLine_bufNameExclude = []
-endif
-
-if !exists("g:indentLine_showFirstIndentLevel")
-    let g:indentLine_showFirstIndentLevel = 0
+if !exists("g:indentLine_init_enabled")
+    let g:indentLine_init_enabled = 1
 endif
 
 set conceallevel=1
 set concealcursor=inc
 
-"{{{1 function! <SID>InitColor()
 function! <SID>InitColor()
     if !exists("g:indentLine_color_term")
         if &bg ==? "light"
@@ -81,80 +59,48 @@ function! <SID>InitColor()
     exec "hi Conceal guifg=" . gui_color .  " guibg=NONE"
 endfunction
 
-"{{{1 function! <SID>SetIndentLine()
 function! <SID>SetIndentLine()
-    let b:indentLine_enabled = 1
-    let space = &l:shiftwidth
-
-    if g:indentLine_showFirstIndentLevel
-        exec 'syn match IndentLine /^ / containedin=ALL conceal cchar=' . g:indentLine_first_char
+    if !exists("b:indentLine_enabled")
+        let b:indentLine_enabled = g:indentLine_enabled
     endif
 
+    let space = &l:shiftwidth
     for i in range(space+1, space * g:indentLine_indentLevel + 1, space)
         exec 'syn match IndentLine /\(^\s\+\)\@<=\%'.i.'v / containedin=ALL conceal cchar=' . g:indentLine_char
     endfor
 endfunction
 
-"{{{1 function! <SID>ResetWidth(...)
 function! <SID>ResetWidth(...)
     if a:0 > 0
         let &l:shiftwidth = a:1
     endif
-
-    if exists("b:indentLine_enabled")
-        syn clear IndentLine
-    endif
+    syn clear IndentLine
     call <SID>SetIndentLine()
 endfunction
 
-"{{{1 function! <SID>IndentLinesToggle()
 function! <SID>IndentLinesToggle()
-    if !exists("b:indentLine_enabled")
-        let b:indentLine_enabled = 0
-    endif
-
-    if b:indentLine_enabled
-        let b:indentLine_enabled = 0
-        syn clear IndentLine
+    if exists("b:indentLine_enabled")
+        if b:indentLine_enabled
+            let b:indentLine_enabled = 0
+            syn clear IndentLine
+        else
+            let b:indentLine_enabled = 1
+            call <SID>SetIndentLine()
+        endif
     else
         call <SID>SetIndentLine()
     endif
 endfunction
 
-"{{{1 function! <SID>Setup()
 function! <SID>Setup()
-    if !getbufvar("%","&hidden") || !exists("b:indentLine_set")
+    if !exists("b:indentLine_set")
         let b:indentLine_set = 1
-
-        if &ft == ""
-            call <SID>InitColor()
-        endif
-
-        if index(g:indentLine_fileTypeExclude, &ft) != -1
-            return
-        endif
-
-        if len(g:indentLine_fileType) != 0 && index(g:indentLine_fileType, &ft) == -1
-            return
-        end
-
-        for name in g:indentLine_bufNameExclude
-            if matchstr(bufname(''), name) == bufname('')
-                return
-            endif
-        endfor
-
-        if !exists("b:indentLine_enabled")
-            let b:indentLine_enabled = g:indentLine_enabled
-        endif
-
-        if b:indentLine_enabled
+        if g:indentLine_init_enabled
             call <SID>SetIndentLine()
         endif
     endif
 endfunction
 
-"{{{1 commands
 autocmd BufWinEnter * call <SID>Setup()
 autocmd BufRead,ColorScheme * call <SID>InitColor()
 


### PR DESCRIPTION
When I develop programs with some kind of languages, I hope by default this plugin is not loaded. Although command: `IndentLinesToggle` is useful, but the plugin is still loaded first when file opened. I add a adding variable so that user can configure whether to load the plugin's feature by editing their '.vimrc'.
