### PR TITLE
Flag for cursorline

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -56,8 +56,11 @@ if !exists("g:indentLine_maxLines")
     let g:indentLine_maxLines = 3000
 endif
 
+if !exists("g:indentLine_noConcealCursor")
+  set concealcursor=inc
+endif
+
 set conceallevel=1
-set concealcursor=inc
 
 "{{{1 function! <SID>InitColor()
 function! <SID>InitColor()

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -90,6 +90,11 @@ g:indentLine_maxLines                           *g:indentLine_maxLines*
                 the performance better.
                 Default value is 3000.
 
+g:indentLine_noConcealCursor                    *g:indentLine_noConcealCursor*
+                This variable toggles cursor lines behavior. If variable
+                exists, then cursorline will be above conceal chars.
+                Default value is not set.
+
 ==============================================================================
 COMMANDS                                         *indentLine-commands*
 


### PR DESCRIPTION
The commit just adds flag in purpose to handle cursor line behavior.

Some pictures:
Flag is not set
![flag_is_not_set](https://f.cloud.github.com/assets/288446/411673/16482294-ab92-11e2-9a8b-c9387ac997b3.png)

Flag is set
![flag_has_been_set](https://f.cloud.github.com/assets/288446/411674/1d3858d0-ab92-11e2-9696-50e6c3b14b49.png)
