### PR TITLE
Calls InitColor on BufNewFile

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -164,7 +164,7 @@ endfunction
 
 "{{{1 commands
 autocmd BufWinEnter * call <SID>Setup()
-autocmd BufRead,ColorScheme * call <SID>InitColor()
+autocmd BufRead,BufNewFile,ColorScheme * call <SID>InitColor()
 
 command! -nargs=? IndentLinesReset call <SID>ResetWidth(<f-args>)
 command! IndentLinesToggle call <SID>IndentLinesToggle()


### PR DESCRIPTION
This commit fixes a bug where color settings are not initialized when a new file is open.
