### PR TITLE
concealcursor and conceallevel to setlocal

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -57,10 +57,10 @@ if !exists("g:indentLine_maxLines")
 endif
 
 if !exists("g:indentLine_noConcealCursor")
-  set concealcursor=inc
+  setlocal concealcursor=inc
 endif
 
-set conceallevel=1
+setlocal conceallevel=1
 
 "{{{1 function! <SID>InitColor()
 function! <SID>InitColor()


### PR DESCRIPTION
Setting these values globally can have various negative reprocussions.
They really should only be set on the file where IndentLine is used.
