### PR TITLE
Fix filetype filtering

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -165,7 +165,7 @@ endfunction
 "{{{1 commands
 autocmd BufWinEnter * call <SID>Setup()
 autocmd BufRead,BufNewFile,ColorScheme * call <SID>InitColor()
-autocmd Syntax * if exists("b:indentLine_set") | call <SID>InitColor() | call <SID>SetIndentLine() | endif
+autocmd Syntax * if exists("b:indentLine_set") && exists("b:indentLine_enabled") && b:indentLine_enabled | call <SID>InitColor() | call <SID>SetIndentLine() | endif
 
 command! -nargs=? IndentLinesReset call <SID>ResetWidth(<f-args>)
 command! IndentLinesToggle call <SID>IndentLinesToggle()


### PR DESCRIPTION
Filetype  filtering some times fails to work. This is because the autocmd for `Syntax` only checks for `b:indentLine_set` but does not check for `b:indentLine_enabled`, if the said autocmds runs after `<SID>Setup()`, indent lines will be displayed regardless of the current filetype.
