### PR TITLE
add the g:indentLine_setColors option

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -60,6 +60,10 @@ if !exists("g:indentLine_faster")
     let g:indentLine_faster = 0
 endif
 
+if !exists("g:indentLine_setColors")
+    let g:indentLine_setColors = 1
+endif
+
 if !exists("g:indentLine_noConcealCursor")
   set concealcursor=inc
 endif
@@ -68,6 +72,10 @@ set conceallevel=1
 
 "{{{1 function! <SID>InitColor()
 function! <SID>InitColor()
+    if !g:indentLine_setColors
+        return
+    endif
+
     if !exists("g:indentLine_color_term")
         if &bg ==? "light"
             let term_color = 249


### PR DESCRIPTION
When g:indentLine_setColors is 1, indentLine will set the Conceal
highlight group's colors using the g:indentLine_color_{term,gui} options
if provided, or choose default colors automatically if not (this is the
existing behavior.) When g:indentLine_setColors is 0, indentLine will
not override the existing colors selected for the Conceal highlight
group. Defaults to 1.
