### PR TITLE
Keep default conceal values for excluded files

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -105,9 +105,23 @@ endfunction
 
 "{{{1 function! s:Setup()
 function! s:Setup()
-    if ! exists("g:indentLine_noConcealCursor")
-        setlocal concealcursor=inc
-    endif
+   if index(g:indentLine_fileTypeExclude, &filetype) isnot -1
+      return
+   endif
+
+   if len(g:indentLine_fileType) isnot 0 && index(g:indentLine_fileType, &filetype) is -1
+      return
+   end
+
+   for name in g:indentLine_bufNameExclude
+      if matchstr(bufname(''), name) is bufname('')
+         return
+      endif
+   endfor
+
+   if ! exists("g:indentLine_noConcealCursor")
+      setlocal concealcursor=inc
+   endif
     setlocal conceallevel=2
 
     if !&hidden || !exists("b:indentLine_set")
@@ -116,20 +130,6 @@ function! s:Setup()
         if &filetype is# ""
             call s:InitColor()
         endif
-
-        if index(g:indentLine_fileTypeExclude, &filetype) isnot -1
-            return
-        endif
-
-        if len(g:indentLine_fileType) isnot 0 && index(g:indentLine_fileType, &filetype) is -1
-            return
-        end
-
-        for name in g:indentLine_bufNameExclude
-            if matchstr(bufname(''), name) is bufname('')
-                return
-            endif
-        endfor
 
         if ! exists("b:indentLine_enabled")
             let b:indentLine_enabled = g:indentLine_enabled


### PR DESCRIPTION
Hello Yggdroot,

Had a little issue with viewing latex files even thought they were part of `g:indentLine_fileTypeExclude`. I changed a few lines of your plugin to accommodate such a situation. 

Setup will now check if the file is part of the included or excluded filetypes before changing the conceal values. I basically moved them from the  `if !&hidden || !exists("b:indentLine_set")` block to beginning of the Setup function. This will allow latex files to be displayed correctly fixing issue #78, without completely disabling the plugin.

Let me know what you think
