### PR TITLE
Exclude auto generated vim doc tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,11 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+
+#############
+## Vim
+#############
+
+# Exclude auto generated vim doc tags.
+doc/tags


### PR DESCRIPTION
A little addition to the .gitignore to exclude the auto generated vim doc tags.
