### PR TITLE
when disable indentLine, donot check the buffer var

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -104,10 +104,8 @@ endfunction
 
 "{{{1 function! s:IndentLinesDisable()
 function! s:IndentLinesDisable()
-    if b:indentLine_enabled
-        let b:indentLine_enabled = 0
-        syntax clear IndentLine
-    endif
+    let b:indentLine_enabled = 0
+    syntax clear IndentLine
 endfunction
 
 "{{{1 function! s:IndentLinesToggle()


### PR DESCRIPTION
since if the disable command was done in autocmd, the `b:indentLine_enabled` was not defined for the buffer, thus got err. And there is no need to check  if it was defined already by `exists(...)`, just setting it as 0 should be fine.