### PR TITLE
mappings to increment or decrement indent

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -25,6 +25,7 @@ let g:indentLine_faster = get(g:,'indentLine_faster',0)
 let g:indentLine_leadingSpaceChar = get(g:,'indentLine_leadingSpaceChar',(&encoding is# "utf-8" && &term isnot# "linux" ? '˰' : '.'))
 let g:indentLine_leadingSpaceEnabled = get(g:,'indentLine_leadingSpaceEnabled',0)
 
+let g:indentLine_tab = 3
 "{{{1 function! s:InitColor()
 function! s:InitColor()
     if ! g:indentLine_setColors
@@ -206,6 +207,19 @@ function! s:LeadingSpaceToggle()
     endif
 endfunction
 
+"{{{1 function! SetTab(incr)
+function! SetTab(incr)
+   let g:indentLine_tab = g:indentLine_tab + a:incr
+   if g:indentLine_tab < 1
+      let g:indentLine_tab = 1
+   endif
+   let &tabstop=g:indentLine_tab
+   let &softtabstop=g:indentLine_tab
+   let &shiftwidth=g:indentLine_tab
+   echo 'tabstop: ' . g:indentLine_tab
+   call s:ResetWidth()
+endfunction
+
 "{{{1 augroup indentLine
 augroup indentLine
     autocmd!
@@ -222,5 +236,9 @@ command! LeadingSpaceEnable call <SID>LeadingSpaceEnable()
 command! LeadingSpaceDisable call <SID>LeadingSpaceDisable()
 command! LeadingSpaceToggle call <SID>LeadingSpaceToggle()
 
+"{{{1 mappings
+map <silent> <Leader>t+ :call SetTab(1)<CR>
+map <silent> <Leader>t- :call SetTab(-1)<CR>
+nmap <leader>ti :IndentLinesToggle<CR>
 " vim:et:ts=4:sw=4:fdm=marker:fmr={{{,}}}
 

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -5,6 +5,7 @@ Introduction                                    |indentLine-introduction|
 Config                                          |indentLine-config|
 Variables                                       |indentLine-variables|
 Commands                                        |indentLine-commands|
+Mappings                                        |indentLine-mappings|
 FAQ                                             |indentLine-faq|
 Changelog                                       |indentLine-changelog|
 Credits                                         |indentLine-credits|
@@ -143,6 +144,13 @@ COMMANDS                                         *indentLine-commands*
 
 *LeadingSpaceToggle*
                 toggle the leading spaces of the current buffer.
+==============================================================================
+MAPPINGS                                         *indentLine-mappings*
+
+<leader>ti      show/hide indentation lines
+<Leader>t+      increment tabstop and refresh
+<Leader>t-      decrement tabstop and refresh
+
 ==============================================================================
 FAQ                                              *indentLine-faq*
 


### PR DESCRIPTION
Allow to adapt to several different files who uses two, four, whatever spaces for indent

Define handy mappings to ease adoption

Review needed:
- [ ] The init of [g:indentLine_tab](https://github.com/albfan/indentLine/blob/master/after/plugin/indentLine.vim#L28) needs a review
- [ ] Maybe [SetTab()](https://github.com/albfan/indentLine/blob/master/after/plugin/indentLine.vim#L211) can be replace with [ResetWidth()](https://github.com/albfan/indentLine/blob/master/after/plugin/indentLine.vim#L102)