### PR TITLE
Fix indendLine doesn't work with 'syntax' option change

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -157,6 +157,11 @@ function! s:Setup()
         call s:InitColor()
     endif
 
+    call s:EnableFeature()
+endfunction
+
+"{{{1 function! s:EnableFeature()
+function! s:EnableFeature() abort
     if g:indentLine_enabled
         call s:IndentLinesEnable()
     endif
@@ -199,7 +204,8 @@ endfunction
 augroup indentLine
     autocmd!
     autocmd BufWinEnter * call <SID>Setup()
-    autocmd BufRead,BufNewFile,ColorScheme,Syntax * call <SID>InitColor()
+    autocmd Syntax * unlet! b:indentLine_enabled | call <SID>EnableFeature()
+    autocmd BufRead,BufNewFile,ColorScheme * call <SID>InitColor()
     autocmd BufUnload * unlet! b:indentLine_enabled
 augroup END
 


### PR DESCRIPTION
### Problem
Fix indendLine doesn't work with 'syntax' option change.
It doen't re-run `:syntax` commands with Syntax autocmd-event.

### Reproduction steps
1. Confirm indentLine is enabled
2. `:syntax off`
  - indendLine is disabled (ok)
3. `:syntax enable`
  - indendLine is disabled (bad. IndentLine should be enabled again )
4. `:IndentLineEnable`
  - indendLine is disabled (bad!)

### Solution
Turn off b:indentLine_enabled and try to enable feature again on Syntax autocmd-event.
