### PR TITLE
Providing new option g:indentLine_setConceal

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This plugin enables the Vim `conceal` feature which automatically hides stretche
 
 For example, users utilizing the built in json.vim syntax file will no longer see quotation marks in their JSON files.
 
-The default settings are:
+indentLine will overwrite your "concealcursor" and "conceallevel" with default value:
 
 ```
 let g:indentLine_concealcursor = 'inc'
@@ -56,6 +56,11 @@ let g:indentLine_conceallevel = 2
 ```
 
 You can customize these settings, but the plugin will not function if `conceallevel` is not set to 1 or 2.
+
+If you want to keep your conceal settting, put this line to your vim dotfile:
+```
+let g:indentLine_setConceal = 0
+```
 
 See the [VIM Reference Manual](http://vimdoc.sourceforge.net/htmldoc/version7.html#new-conceal) for more information on the `conceal` feature.
 

--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -21,6 +21,7 @@ let g:indentLine_bufNameExclude = get(g:,'indentLine_bufNameExclude',[])
 let g:indentLine_showFirstIndentLevel = get(g:,'indentLine_showFirstIndentLevel',0)
 let g:indentLine_maxLines = get(g:,'indentLine_maxLines',3000)
 let g:indentLine_setColors = get(g:,'indentLine_setColors',1)
+let g:indentLine_setConceal = get(g:,'indentLine_setConceal',1)
 let g:indentLine_faster = get(g:,'indentLine_faster',0)
 let g:indentLine_leadingSpaceChar = get(g:,'indentLine_leadingSpaceChar',(&encoding ==# "utf-8" && &term isnot# "linux" ? '˰' : '.'))
 let g:indentLine_leadingSpaceEnabled = get(g:,'indentLine_leadingSpaceEnabled',0)
@@ -67,6 +68,9 @@ endfunction
 
 "{{{1 function! s:SetConcealOption()
 function! s:SetConcealOption()
+    if ! g:indentLine_setConceal
+        return
+    endif
     if ! exists("b:indentLine_ConcealOptionSet")
         let b:indentLine_ConcealOptionSet = 1
         let &l:concealcursor = exists("g:indentLine_concealcursor") ? g:indentLine_concealcursor : "inc"

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -111,6 +111,12 @@ g:indentLine_faster                             *g:indentLine_faster*
                 1, default value is 0. But better performance may bring little
                 issue with it.
 
+g:indentLine_setConceal
+                The plugin will overwrite your "concealcursor" and
+                "conceallevel" by default. If you want to keep your setting,
+                set this value to 0.
+                Default value is 1.
+
 g:indentLine_concealcursor                    *g:indentLine_concealcursor*
                 This variable toggles cursor lines behavior. If variable
                 exists and is empty, that is, set to '', then the indentlines


### PR DESCRIPTION
indentLine will overwrite user's "conceallevel" and "concealcursor" value by default. It's convenient if users didn't set any conceal value in their dotfile or plugin.

If they set custom conceal value, it confuse them when their setting didn't work. So maybe we should   provide an option to keep their setting.