### PR TITLE
Fixed set conceal options

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -139,6 +139,8 @@ endfunction
 "{{{1 function! s:Setup()
 function! s:Setup()
     if index(g:indentLine_fileTypeExclude, &filetype) isnot -1
+        let &l:concealcursor = ""
+        let &l:conceallevel = "0"
         return
     endif
 
@@ -198,7 +200,7 @@ endfunction
 "{{{1 augroup indentLine
 augroup indentLine
     autocmd!
-    autocmd BufWinEnter * call <SID>Setup()
+    autocmd BufEnter * call <SID>Setup()
     autocmd User * if exists("b:indentLine_enabled") && b:indentLine_enabled ||
                     \ exists("b:indentLine_leadingSpaceEnabled") && b:indentLine_leadingSpaceEnabled |
                     \ call <SID>Setup() |

--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -200,7 +200,7 @@ endfunction
 "{{{1 augroup indentLine
 augroup indentLine
     autocmd!
-    autocmd BufEnter * call <SID>Setup()
+    autocmd BufWinEnter,BufEnter * call <SID>Setup()
     autocmd User * if exists("b:indentLine_enabled") && b:indentLine_enabled ||
                     \ exists("b:indentLine_leadingSpaceEnabled") && b:indentLine_leadingSpaceEnabled |
                     \ call <SID>Setup() |


### PR DESCRIPTION
This change was necessary because the let &l:concealcursor and &l:conceallevel when set locally will set it to the entire window (vim documentation), so it need to be reset every time the buffer changes.