### PR TITLE
Fix indent lines after using ownsyntax

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -204,10 +204,11 @@ augroup indentLine
                     \ call <SID>Setup() |
                     \ endif
 
-    autocmd BufRead,BufNewFile,ColorScheme,Syntax * call <SID>InitColor()
+    autocmd BufRead,BufNewFile,ColorScheme * call <SID>InitColor()
     autocmd BufUnload * let b:indentLine_enabled = 0 | let b:indentLine_leadingSpaceEnabled = 0
     autocmd SourcePre $VIMRUNTIME/syntax/nosyntax.vim doautocmd indentLine BufUnload
     autocmd FileChangedShellPost * doautocmd indentLine BufUnload | call <SID>Setup()
+    autocmd Syntax * doautocmd indentLine BufUnload | call <SID>Setup()
 augroup END
 
 "{{{1 commands


### PR DESCRIPTION
Vim resets the syntax highlighting when the 'ownsyntax' command is used.
This also triggers a new Syntax event, but indentLine did not reapply
its syntax rules because indentLine_enabled is still set.
Now we explicitly unset indentLine_enabled and call Setup again to
ensure everything is working again.

See jeaye/color_coded#147.