### PR TITLE
Add left-aligned unicode characters to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Vim and GVim
 ```
 let g:indentLine_char = 'c'
 ```
-where `'c'` can be any ASCII character. You can also use one of `¦`, `┆`, or `│` to display more beautiful lines. However, these characters will only work with files whose encoding is UTF-8.
+where `'c'` can be any ASCII character. You can also use one of `¦`, `┆`, `│`, `⎸`, or `▏` to display more beautiful lines. However, these characters will only work with files whose encoding is UTF-8.
 
 **Change Conceal Behaviour**
 


### PR DESCRIPTION
LEFT VERTICAL BOX LINE: `⎸`
LEFT ONE EIGHTH BLOCK: `▏`

These unicode character are displayed all the way to the left of the column instead of in the center like the other unicode character suggestions. I think it's easier to look at.

LEFT ONE EIGHTH BLOCK looks the best in my terminal.