### PR TITLE
Add background color (ctermbg, guibg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ Or you can customize conceal color by:
 " Vim
 let g:indentLine_color_term = 239
 
-"GVim
+" GVim
 let g:indentLine_color_gui = '#A4E57E'
 
 " none X terminal
 let g:indentLine_color_tty_light = 7 " (default: 4)
 let g:indentLine_color_dark = 1 " (default: 2)
+
+" Background (Vim, GVim)
+let g:indentLine_bgcolor_term = 202
+let g:indentLine_bgcolor_gui = '#FF5F00'
 ```
 
 **Change Indent Char**

--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -44,6 +44,12 @@ function! s:InitColor()
         let term_color = g:indentLine_color_term
     endif
 
+    if !exists("g:indentLine_bgcolor_term")
+        let term_bgcolor = "NONE"
+    else
+        let term_bgcolor = g:indentLine_bgcolor_term
+    endif
+
     if !exists("g:indentLine_color_gui")
         if &background ==# "light"
             let gui_color = "Grey70"
@@ -54,8 +60,14 @@ function! s:InitColor()
         let gui_color = g:indentLine_color_gui
     endif
 
-    execute "highlight Conceal cterm=NONE ctermfg=" . term_color . " ctermbg=NONE"
-    execute "highlight Conceal gui=NONE guifg=" . gui_color .  " guibg=NONE"
+    if !exists("g:indentLine_bgcolor_gui")
+        let gui_bgcolor = "NONE"
+    else
+        let gui_bgcolor = g:indentLine_bgcolor_gui
+    endif
+
+    execute "highlight Conceal cterm=NONE ctermfg=" . term_color . " ctermbg=" . term_bgcolor
+    execute "highlight Conceal gui=NONE guifg=" . gui_color .  " guibg=" . gui_bgcolor
 
     if &term ==# "linux"
         if &background ==# "light"

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -47,10 +47,18 @@ g:indentLine_color_term                         *g:indentLine_color_term*
                 Specify terminal vim indent line color.
                 e.g.  let g:indentLine_color_term = 239
 
+g:indentLine_bgcolor_term                       *g:indentLine_bgcolor_term*
+                Specify terminal vim indent line background color.
+                e.g.  let g:indentLine_color_term = 202
+
 
 g:indentLine_color_gui                          *g:indentLine_color_gui*
                 Specify GUI vim indent line color.
                 e.g.  let g:indentLine_color_gui = '#A4E57E'
+
+g:indentLine_bgcolor_gui                        *g:indentLine_bgcolor_gui*
+                Specify GUI vim indent line background color.
+                e.g.  let g:indentLine_color_gui = '#FF5F00'
 
 g:indentLine_color_tty_light                    *g:indentLine_color_tty_light*
                 Specify none X terminal vim indent line color in bg light.


### PR DESCRIPTION
Hi,

I've added basic support for background color. 
It looks quite good IMO, and it easier to copy text from terminal (no extra characters).

![image](https://user-images.githubusercontent.com/5898312/28408469-d9182948-6d37-11e7-9730-983d41d063ce.png)
