### PR TITLE
Allow to exclude by buffer types

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -19,6 +19,7 @@ let g:indentLine_enabled = get(g:, 'indentLine_enabled', 1)
 let g:indentLine_fileType = get(g:, 'indentLine_fileType', [])
 let g:indentLine_fileTypeExclude = get(g:, 'indentLine_fileTypeExclude', [])
 let g:indentLine_bufNameExclude = get(g:, 'indentLine_bufNameExclude', [])
+let g:indentLine_bufTypeExclude = get(g:, 'indentLine_bufTypeExclude', [])
 let g:indentLine_showFirstIndentLevel = get(g:, 'indentLine_showFirstIndentLevel', 0)
 let g:indentLine_maxLines = get(g:, 'indentLine_maxLines', 3000)
 let g:indentLine_setColors = get(g:, 'indentLine_setColors', 1)
@@ -207,6 +208,10 @@ endfunction
 "{{{1 function! s:Filter()
 function! s:Filter()
     if index(g:indentLine_fileTypeExclude, &filetype) != -1
+        return 0
+    endif
+
+    if index(g:indentLine_bufTypeExclude, &buftype) != -1
         return 0
     endif
 

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -101,6 +101,13 @@ g:indentLine_fileTypeExclude                    *g:indentLine_fileTypeExclude*
                 e.g. let g:indentLine_fileTypeExclude = ['text', 'sh']
                 Default value is [] which means no file types is excluded.
 
+g:indentLine_bufTypeExclude                    *g:indentLine_bufTypeExclude*
+                This variable specify a list of buffer types.
+                When opening these types of buffers, the plugin is disabled
+                by default.
+                e.g. let g:indentLine_bufTypeExclude = ['help', 'terminal']
+                Default value is [] which means no buffer type is excluded.
+
 g:indentLine_bufNameExclude                     *g:indentLine_bufNameExclude*
                 This variable specify a list of buffer names, which can be
                 regular expression. If the buffer's name fall into this list,

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -99,7 +99,7 @@ g:indentLine_fileTypeExclude                    *g:indentLine_fileTypeExclude*
                 When opening these types of files, the plugin is disabled by
                 default.
                 e.g. let g:indentLine_fileTypeExclude = ['text', 'sh']
-                Default value is [] which means no file types is excluded.
+                Default value is [] which means no file types are excluded.
 
 g:indentLine_bufTypeExclude                    *g:indentLine_bufTypeExclude*
                 This variable specify a list of buffer types.


### PR DESCRIPTION
This is useful for Neovim terminal, which doesn't set the filetype but buftype `terminal`.