### PR TITLE
Don't conceal during insert mode

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -86,7 +86,7 @@ function! s:SetConcealOption()
     endif
     if !exists("b:indentLine_ConcealOptionSet")
         let b:indentLine_ConcealOptionSet = 1
-        let &l:concealcursor = exists("g:indentLine_concealcursor") ? g:indentLine_concealcursor : "inc"
+        let &l:concealcursor = exists("g:indentLine_concealcursor") ? g:indentLine_concealcursor : "nc"
         let &l:conceallevel = exists("g:indentLine_conceallevel") ? g:indentLine_conceallevel : "2"
     endif
 endfunction


### PR DESCRIPTION
Conceal during insert mode conflicts badly with TeX conceal.
It becomes practically impossible to edit TeX files.

To see the issue, create a file called test.tex, with the following content:

$\frac{\partial u}{\partial t}=t^2$

Before this change, \partial will be concealed with a single unicode character, even when editing.
After this change, conceal will be deactivated on the current line while in insert mode.