### PR TITLE
Mitigate problems caused by default json syntax concealing quotes

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -85,10 +85,20 @@ function! s:SetConcealOption()
     if !g:indentLine_setConceal
         return
     endif
-    if !exists("b:indentLine_ConcealOptionSet")
+    if !(exists("b:indentLine_ConcealOptionSet") && b:indentLine_ConcealOptionSet)
         let b:indentLine_ConcealOptionSet = 1
+        let b:indentLine_original_concealcursor = &l:concealcursor
+        let b:indentLine_original_conceallevel = &l:conceallevel
         let &l:concealcursor = exists("g:indentLine_concealcursor") ? g:indentLine_concealcursor : "inc"
         let &l:conceallevel = exists("g:indentLine_conceallevel") ? g:indentLine_conceallevel : "2"
+    endif
+endfunction
+
+function! s:ResetConcealOption()
+    if exists("b:indentLine_ConcealOptionSet") && b:indentLine_ConcealOptionSet
+        let &l:concealcursor = b:indentLine_original_concealcursor
+        let &l:conceallevel = b:indentLine_original_conceallevel
+        let b:indentLine_ConcealOptionSet = 0
     endif
 endfunction
 
@@ -162,6 +172,7 @@ function! s:IndentLinesDisable()
             let w:indentLine_indentLineId = []
         endif
 
+        call s:ResetConcealOption()
         return
     endif
 

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -180,10 +180,14 @@ COMMANDS                                         *indentLine-commands*
 ==============================================================================
 FAQ                                              *indentLine-faq*
 
-Q. How can I make the indent line visuall similar to the line used in Sublime
+Q. How can I make the indent line visual similar to the line used in Sublime
     Text 2?
 
 A. Use let g:indentLine_char = '┊'
+
+Q. I don't see quotes in JSON.
+
+A. Use let g:vim_json_syntax_conceal = 0 or run :IndentLinesDisable
 
 ==============================================================================
 CHANGELOG                                        *indentLine-changelog*


### PR DESCRIPTION
* Respect original values of 'concealcursor' and 'conceallevel', so
  when user disables indentLine - quotes in JSON are back.
* Mention this problem in FAQ to save time.

#140 