### PR TITLE
Allow colors to be defaulted to specified hl group

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -24,6 +24,7 @@ let g:indentLine_showFirstIndentLevel = get(g:, 'indentLine_showFirstIndentLevel
 let g:indentLine_maxLines = get(g:, 'indentLine_maxLines', 3000)
 let g:indentLine_setColors = get(g:, 'indentLine_setColors', 1)
 let g:indentLine_setConceal = get(g:, 'indentLine_setConceal', 1)
+let g:indentLine_defaultGroup = get(g:, 'indentLine_defaultGroup', "")
 let g:indentLine_faster = get(g:, 'indentLine_faster', 0)
 let g:indentLine_leadingSpaceChar = get(g:, 'indentLine_leadingSpaceChar', (&encoding ==# "utf-8" && &term isnot# "linux" ? '˰' : '.'))
 let g:indentLine_leadingSpaceEnabled = get(g:, 'indentLine_leadingSpaceEnabled', 0)
@@ -35,34 +36,44 @@ function! s:InitColor()
         return
     endif
 
+    let default_term_bg = "NONE"
+    let default_gui_bg  = "NONE"
+    if &background ==# "light"
+        let default_term_fg = 249
+        let default_gui_fg = "Grey70"
+    else
+        let default_term_fg = 239
+        let default_gui_fg = "Grey30"
+    endif
+
+    if g:indentLine_defaultGroup != ""
+        let default_id = synIDtrans(hlID(g:indentLine_defaultGroup))
+        let default_term_fg = synIDattr(default_id, "fg", "term") == "" ? default_term_fg :  synIDattr(default_id, "fg", "term")
+        let default_term_bg = synIDattr(default_id, "bg", "term") == "" ? default_term_bg :  synIDattr(default_id, "bg", "term")
+        let default_gui_fg = synIDattr(default_id, "fg", "gui") == "" ? default_gui_fg :  synIDattr(default_id, "fg", "gui")
+        let default_gui_bg = synIDattr(default_id, "bg", "gui") == "" ? default_gui_bg :  synIDattr(default_id, "bg", "gui")
+    endif
+
     if !exists("g:indentLine_color_term")
-        if &background ==# "light"
-            let term_color = 249
-        else
-            let term_color = 239
-        endif
+        let term_color = default_term_fg
     else
         let term_color = g:indentLine_color_term
     endif
 
     if !exists("g:indentLine_bgcolor_term")
-        let term_bgcolor = "NONE"
+        let term_bgcolor = default_term_bg
     else
         let term_bgcolor = g:indentLine_bgcolor_term
     endif
 
     if !exists("g:indentLine_color_gui")
-        if &background ==# "light"
-            let gui_color = "Grey70"
-        else
-            let gui_color = "Grey30"
-        endif
+        let gui_color = default_gui_fg
     else
         let gui_color = g:indentLine_color_gui
     endif
 
     if !exists("g:indentLine_bgcolor_gui")
-        let gui_bgcolor = "NONE"
+        let gui_bgcolor = default_gui_bg
     else
         let gui_bgcolor = g:indentLine_bgcolor_gui
     endif

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -152,6 +152,10 @@ g:indentLine_leadingSpaceChar                   *g:indentLine_leadingSpaceChar*
 g:indentLine_leadingSpaceEnabled                *g:indentLine_leadingSpaceEnabled*
                 Specify whether to show leading spaces by default.
                 Default value is 0.
+
+g:indentLine_defaultGroup                       g:indentLine_defaultGroup
+                Spceify a highlight group to use for default values
+				of g:indentLine_[bg]color_(term|gui)
 ==============================================================================
 COMMANDS                                         *indentLine-commands*
 

--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -153,7 +153,7 @@ g:indentLine_leadingSpaceEnabled                *g:indentLine_leadingSpaceEnable
                 Specify whether to show leading spaces by default.
                 Default value is 0.
 
-g:indentLine_defaultGroup                       g:indentLine_defaultGroup
+g:indentLine_defaultGroup                       *g:indentLine_defaultGroup*
                 Spceify a highlight group to use for default values
 				of g:indentLine_[bg]color_(term|gui)
 ==============================================================================


### PR DESCRIPTION
Allow colors to be default to specified HL group colors.  

For example
```
let g:indentLine_defaultGroup = "Whitespace"
let g:indentLine_char = '|'
```
Would causes indentLines to (mostly) match  `set list lcs=tab:\|\ `