### PR TITLE
Fix unexpected feature enabling by AutoResetWidth

### DIFF
--- a/after/plugin/indentLine.vim
+++ b/after/plugin/indentLine.vim
@@ -268,7 +268,7 @@ function! s:AutoResetWidth()
     let l:enable = get(
                     \ b:,
                     \ 'indentLine_enabled',
-                    \ get(g:, 'indentLine_enabled', 1)
+                    \ g:indentLine_enabled ? s:Filter() : 0
                     \)
 
     let g:indentLine_autoResetWidth = get(g:, 'indentLine_autoResetWidth', 1)


### PR DESCRIPTION
First, thank you for your great plugin. It's very helpful.

I found that this feature is unexpectedly enabled on help file by `AutoResetWidth`. This is caused because help files have modeline that sets `shiftwidth` or `tabstop` buffer locally, and `AutoResetWidth` just refers to `b:indentLine_enabled` and `g:indentLine_enabled`, but not filter settings. In other cases, just typing `:set shiftwidth=4` can cause the same issue. And this probably be the same issue as #306.

I've created my fix. Could you merge this if it looks good?

How to fix: When `b:indentLine_enabled` doesn't exist and `g:indentLine_enabled` == 1, refer to `s:Filter()` instead of the value itself.

CC: @matveyt, @Mike325 