### PR TITLE
Fix typo in g:indentLine_bgcolor_gui

### DIFF
--- a/doc/indentLine.txt
+++ b/doc/indentLine.txt
@@ -62,7 +62,7 @@ g:indentLine_color_gui                          *g:indentLine_color_gui*
 
 g:indentLine_bgcolor_gui                        *g:indentLine_bgcolor_gui*
                 Specify GUI vim indent line background color.
-                e.g.  let g:indentLine_color_gui = '#FF5F00'
+                e.g.  let g:indentLine_bgcolor_gui = '#FF5F00'
 
 g:indentLine_color_tty_light                    *g:indentLine_color_tty_light*
                 Specify none X terminal vim indent line color in bg light.


### PR DESCRIPTION
While giving the example of option `indentLine_bgcolor_gui` there is a
typo in which doc uses
> e.g.  let g:indentLine_color_gui = '#FF5F00'

instead of 
> e.g.  let g:indentLine_bgcolor_gui = '#FF5F00'